### PR TITLE
Automate package releases and Pages deployment

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,6 +2,11 @@
 
 This repository uses Changesets to manage package versions and npm releases.
 
-Run `pnpm changeset` in feature PRs that affect published packages. Merging
-changesets to `main` creates or updates a version PR. Merging that version PR
-publishes the bumped public packages.
+Run `pnpm changeset` in every feature PR that affects a published package and
+commit the generated Markdown file. Merging changesets to `main` creates or
+updates the automated `Version Packages` PR. Review and merge that PR to
+publish the bumped packages, Git tags, and GitHub Releases.
+
+Changes under `page/` deploy independently to GitHub Pages after they reach
+`main`; they do not require a changeset. See [the release guide](../docs/releasing.md)
+for the full workflow and recovery rules.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - next/acpus_ts_workflow
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,13 +1,13 @@
 name: Deploy Pages
-run-name: Deploy Pages from ${{ inputs.release_sha }}
+run-name: Deploy Pages from ${{ github.sha }}
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - page/**
   workflow_dispatch:
-    inputs:
-      release_sha:
-        description: Full published commit SHA currently at origin/main
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -16,26 +16,20 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
-          ref: ${{ inputs.release_sha }}
+          ref: ${{ github.sha }}
 
-      - name: Verify published main commit
-        env:
-          RELEASE_SHA: ${{ inputs.release_sha }}
-        run: |
-          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
-          test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
+      - name: Verify main commit
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,17 @@
-name: Publish stable to npm
-run-name: Publish stable from ${{ inputs.release_sha }}
+name: Release packages
+run-name: Release packages from ${{ github.sha }}
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - .changeset/**
+      - packages/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
   workflow_dispatch:
-    inputs:
-      release_sha:
-        description: Full audited commit SHA currently at origin/main
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -18,22 +22,20 @@ concurrency:
 
 jobs:
   verify:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ inputs.release_sha }}
+          ref: ${{ github.sha }}
 
-      - name: Verify audited main commit
-        env:
-          RELEASE_SHA: ${{ inputs.release_sha }}
-        run: |
-          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
-          test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
+      - name: Verify main commit
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - name: Verify stable release mode
+        run: test ! -f .changeset/pre.json
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -52,7 +54,6 @@ jobs:
       - run: pnpm check:dependencies
       - run: pnpm check:dependencies:strict
       - run: pnpm check:docs
-      - run: pnpm check:release
       - run: pnpm check:security
       - run: pnpm test
       - run: pnpm test:dist
@@ -68,21 +69,15 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ inputs.release_sha }}
+          ref: ${{ github.sha }}
 
-      - name: Reverify audited main commit
-        env:
-          RELEASE_SHA: ${{ inputs.release_sha }}
-        run: |
-          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
-          test "$(git rev-parse refs/remotes/origin/main)" = "$RELEASE_SHA"
+      - name: Reverify main commit
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -96,15 +91,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:clean
-      - run: pnpm check:release
       - run: pnpm check:security
       - run: pnpm test:dist
 
-      - name: Publish stable packages
+      - name: Create version PR or publish stable packages
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
+          version: pnpm version-packages
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ see the [Acpus 0.5.2 README](https://github.com/kelvinschen/acpus/blob/acpus%400
 
 - [Bundled Acpus Skill](packages/cli/skills/acpus/SKILL.md)
 - [Migration Guide](docs/migrate-to-next.md)
-- [Main Replacement Release Runbook](docs/main-replacement-release-runbook.md)
+- [Release Guide](docs/releasing.md)
+- [Acpus 0.6 Main Replacement Record](docs/main-replacement-release-runbook.md)
 - [Specs Index](specs/INDEX.md)
 - [Core Spec](specs/core-spec.md)
 - [Expression Spec](specs/expression-spec.md)

--- a/docs/main-replacement-release-runbook.md
+++ b/docs/main-replacement-release-runbook.md
@@ -1,5 +1,8 @@
 # Replace `main` and Publish Acpus 0.6
 
+> This is the historical runbook for the one-time Acpus 0.6 main replacement.
+> Ongoing package and Pages releases use the [release guide](releasing.md).
+
 This runbook promotes the TypeScript-first Acpus line to stable by replacing
 the Git tree at `main`. It does **not** merge, rebase, or cherry-pick the old
 `main` history into `next/acpus_ts_workflow`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,55 @@
+# Release Acpus
+
+Acpus uses Changesets for npm package releases and deploys the static product
+page independently. Both automations run only from `main`.
+
+## Publish packages
+
+Every pull request that changes a published package must include a changeset:
+
+```sh
+pnpm changeset
+```
+
+Choose the affected packages and the smallest correct semantic-version bump,
+then commit the generated `.changeset/*.md` file with the implementation.
+
+After the feature pull request reaches `main`, the `Release packages` workflow:
+
+1. runs the release verification suite;
+2. creates or updates the `Version Packages` pull request with package versions,
+   changelogs, the lockfile, and the bundled Acpus Skill version;
+3. waits for that pull request to be reviewed and merged;
+4. publishes the changed packages to npm and creates their Git tags and GitHub
+   Releases from the merged version commit.
+
+The `npm` GitHub Environment supplies `NPM_TOKEN`. It must allow deployments
+without required-reviewer approval for publishing to be fully automatic.
+Repository Actions must allow `GITHUB_TOKEN` to write contents and pull
+requests so Changesets can maintain the version pull request and release tags.
+GitHub may require a maintainer to approve CI on a pull request created by
+`GITHUB_TOKEN`; use a GitHub App installation token if that approval should
+also be automated.
+
+Do not edit package versions by hand. Do not rerun a partially failed publish
+until the versions that reached npm have been inventoried. npm releases are
+fixed forward with a new changeset; they are not rolled back by moving `main`.
+Stable automation refuses to run while Changesets prerelease mode is active;
+prereleases continue to use the separate alpha workflow.
+
+## Deploy the product page
+
+Any change under `page/` deploys automatically after it reaches `main`. The
+`Deploy Pages` workflow uploads the directory as-is and deploys it through the
+`github-pages` Environment. A manual dispatch remains available to restore the
+current `main` page after an interrupted or failed deployment.
+
+Page-only pull requests do not need a changeset and do not start the package
+release workflow.
+
+## Manual recovery
+
+Both workflows retain `workflow_dispatch` as a recovery entry point. Dispatch
+them only from `main`; each workflow checks that the checkout matches the event
+commit. Prefer fixing the failed workflow or configuration over bypassing its
+verification steps.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:dist": "node scripts/verify-dist.js",
     "changeset": "changeset",
     "version-packages": "changeset version && node scripts/sync-acpus-skill-version.mjs && pnpm install --lockfile-only",
-    "ci:publish": "changeset publish",
+    "ci:publish": "pnpm check:release && changeset publish",
     "clean": "pnpm -r clean"
   },
   "devDependencies": {

--- a/scripts/verify-build-toolchain.mjs
+++ b/scripts/verify-build-toolchain.mjs
@@ -54,6 +54,7 @@ equal(rootManifest.scripts?.["check:docs"], "node scripts/verify-doc-links.mjs",
 equal(rootManifest.scripts?.["check:release"], "node scripts/verify-release-state.mjs", "release check script");
 equal(rootManifest.scripts?.["check:security"], "pnpm audit --audit-level high", "security check script");
 equal(rootManifest.scripts?.["version-packages"], "changeset version && node scripts/sync-acpus-skill-version.mjs && pnpm install --lockfile-only", "version packages script");
+equal(rootManifest.scripts?.["ci:publish"], "pnpm check:release && changeset publish", "publish script");
 const cliManifest = manifests.get("cli");
 const skillVersion = (await text("packages/cli/skills/acpus/SKILL.md")).match(/^\s+acpus-version:\s*([^\s#]+)/mu)?.[1];
 equal(skillVersion, cliManifest.version, "bundled Acpus skill version");


### PR DESCRIPTION
## Summary

- run package release automation on relevant pushes to `main`
- create or update the Changesets `Version Packages` PR, then publish npm packages, tags, and GitHub Releases after that PR is merged
- deploy GitHub Pages automatically for `page/**` changes
- move push CI from the retired next branch to `main`
- document the ongoing release and recovery process

## Release safety

- pending changesets are allowed while the version PR is prepared
- `pnpm check:release` still runs immediately before `changeset publish`
- stable automation rejects Changesets prerelease mode
- both release workflows retain a manual dispatch fallback
- package and Pages workflows are serialized independently

## Validation

- `actionlint`
- `pnpm install --frozen-lockfile`
- `pnpm build:clean`
- `pnpm typecheck`
- `pnpm check:build-toolchain`
- `pnpm check:dead-code`
- `pnpm check:dependencies`
- `pnpm check:dependencies:strict`
- `pnpm check:docs`
- `pnpm check:release`
- `pnpm check:security`
- `pnpm test`
- `pnpm test:dist`
- generated Web assets unchanged

## Post-merge handoff

- confirm the `npm` Environment has no required-reviewer gate if publishing should be fully automatic
- manually dispatch `Deploy Pages` once from `main` so the Logo commits that predate this workflow change are deployed
