### PR TITLE
feat(design-forge): publish readable design documents

### DIFF
--- a/.changeset/readable-design-forge.md
+++ b/.changeset/readable-design-forge.md
@@ -1,0 +1,5 @@
+---
+"acpus": patch
+---
+
+Publish reader-facing Markdown from the bundled design-forge workflow with structured references, decision and diagram planning, deterministic publication checks, and separate audit artifacts.

--- a/.changeset/readable-design-forge.md
+++ b/.changeset/readable-design-forge.md
@@ -2,4 +2,4 @@
 "acpus": patch
 ---
 
-Publish reader-facing Markdown from the bundled design-forge workflow with structured references, decision and diagram planning, deterministic publication checks, and separate audit artifacts.
+Publish a reader-facing Markdown document from the bundled design-forge workflow, with Agent-directed structure, optional diagrams and references, readability-aware resident challenges, and a separate review log.

--- a/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
+++ b/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
@@ -388,16 +388,14 @@ export default defineWorkflow({
       workspaceDir: meta.workspaceDir,
     },
     exec: async ({ input, $, artifact }) => {
-      const [brief, design, referencesText, decisions, diagramPlan, fitness, failure, simplicity] = await Promise.all([
-        $`cat brief.txt`.text(),
-        $`cat design.txt`.text(),
-        $`cat references.json`.text(),
-        $`cat decision-log.md`.text(),
-        $`cat diagram-plan.md`.text(),
-        $`cat reviews/fitness.txt`.text(),
-        $`cat reviews/failure.txt`.text(),
-        $`cat reviews/simplicity.txt`.text(),
-      ]);
+      const brief = await $`cat brief.txt`.text();
+      const design = await $`cat design.txt`.text();
+      const referencesText = await $`cat references.json`.text();
+      const decisions = await $`cat decision-log.md`.text();
+      const diagramPlan = await $`cat diagram-plan.md`.text();
+      const fitness = await $`cat reviews/fitness.txt`.text();
+      const failure = await $`cat reviews/failure.txt`.text();
+      const simplicity = await $`cat reviews/simplicity.txt`.text();
 
       const document = design.trim();
       if (document.length < 800 || document.includes("Replace every instructional placeholder")) {

--- a/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
+++ b/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
@@ -1,7 +1,7 @@
 /*
  * Pattern: Develop one reader-facing design through three resident challenge
- * conversations sharing a run-scoped blackboard, then publish the design and a
- * separate audit package.
+ * conversations sharing a run-scoped text blackboard, then publish the design
+ * separately from the review history.
  * Scale: at most maxRounds × (1 designer + 3 challengers); peak ready Agents: 3.
  * Nodes: agent, task, if, parallel, loop
  */
@@ -14,10 +14,10 @@ const Completion = z.object({
 
 export default defineWorkflow({
   name: "design-forge",
-  description: "Develop and publish a decision-ready Markdown design through resident challenges on a shared blackboard.",
+  description: "Develop and publish a readable Markdown design through resident challenges on a shared text blackboard.",
   inputSchema: z.object({
     brief: z.string().describe(
-      "The problem, audience, goals, constraints, success criteria, and any known references for the design.",
+      "The problem, audience, goals, constraints, success criteria, and any useful starting context for the design.",
     ),
     maxRounds: z.number().int().positive().default(5).describe(
       "Maximum number of design and challenge rounds.",
@@ -40,73 +40,10 @@ export default defineWorkflow({
         if (existing.exitCode !== 0) await $`printf %s ${content} > ${path}`;
       };
 
-      const designTemplate = [
-        "# Design proposal",
-        "",
-        "> Status: Draft. Replace every instructional placeholder before publication.",
-        "",
-        "<!-- design-forge:summary -->",
-        "## Decision at a glance",
-        "Explain the recommendation, its audience, and the outcome it enables.",
-        "",
-        "<!-- design-forge:context -->",
-        "## Context, scope, and success criteria",
-        "Explain the current state, goals, non-goals, constraints, assumptions, and measurable success criteria.",
-        "",
-        "<!-- design-forge:options -->",
-        "## Options and decision",
-        "Compare credible alternatives, then explain the selected option and its consequences.",
-        "",
-        "<!-- design-forge:design -->",
-        "## Proposed design",
-        "Describe boundaries, responsibilities, interfaces, data, control flow, and selected diagrams.",
-        "",
-        "<!-- design-forge:operations -->",
-        "## Reliability, security, and operations",
-        "Cover failure behavior, recovery, security boundaries, observability, and the operating model.",
-        "",
-        "<!-- design-forge:risks -->",
-        "## Risks, assumptions, and open questions",
-        "Distinguish accepted trade-offs from unresolved questions and residual risks.",
-        "",
-        "<!-- design-forge:delivery -->",
-        "## Delivery and validation",
-        "Describe rollout, migration, testing, compatibility, ownership, and rollback.",
-        "",
-        "<!-- design-forge:references -->",
-        "## References",
-        "List only sources registered in references.json and cite them by stable ID.",
-        "",
-      ].join("\n");
-      const referenceTemplate = `${JSON.stringify({
-        schemaVersion: 1,
-        external: [],
-        workspace: [],
-      }, null, 2)}\n`;
-      const decisionTemplate = [
-        "# Decision log",
-        "",
-        "Track architecturally significant choices with stable IDs such as D-001.",
-        "",
-        "| ID | Status | Decision | Context and rationale | Alternatives | Consequences and reversibility |",
-        "| --- | --- | --- | --- | --- | --- |",
-        "",
-      ].join("\n");
-      const diagramTemplate = [
-        "# Diagram plan",
-        "",
-        "For every selected or rejected visual, record the reader question, diagram type, scope, and rationale.",
-        "A diagram is optional when prose or a compact table communicates the design more clearly.",
-        "",
-      ].join("\n");
-
       await $`mkdir -p ${`${root}/reviews`}`;
       await $`chmod 700 ${root}`;
       await writeOnce(`${root}/brief.txt`, `${input.brief}\n`);
-      await writeOnce(`${root}/design.txt`, designTemplate);
-      await writeOnce(`${root}/references.json`, referenceTemplate);
-      await writeOnce(`${root}/decision-log.md`, decisionTemplate);
-      await writeOnce(`${root}/diagram-plan.md`, diagramTemplate);
+      await writeOnce(`${root}/design.txt`, "No design has been written yet.\n");
       await writeOnce(`${root}/reviews/fitness.txt`, "No fitness review has been recorded yet.\n");
       await writeOnce(`${root}/reviews/failure.txt`, "No failure review has been recorded yet.\n");
       await writeOnce(`${root}/reviews/simplicity.txt`, "No simplicity review has been recorded yet.\n");
@@ -126,119 +63,61 @@ export default defineWorkflow({
         agent: agents.designer,
         cwd: blackboard.output.root,
         prompt: md`
-          Role
-          You are the design owner and publication author. Develop the design and
-          maintain one reader-facing Markdown document that a decision maker,
-          implementer, operator, and future maintainer can understand without
-          reading the review notebooks.
+          You own both the design and the document that communicates it.
 
-          Blackboard
-          Work directly in ${blackboard.output.root}. Read brief.txt, design.txt,
-          references.json, decision-log.md, diagram-plan.md, and all three files
-          under reviews/. The source workspace is ${meta.workspaceDir}; inspect it
-          when useful, but modify only files in the blackboard.
+          Work directly in the text blackboard at ${blackboard.output.root}. Read
+          brief.txt, design.txt, and the three files under reviews/. The source
+          workspace is ${meta.workspaceDir}; inspect it when useful. You may also
+          consult public sources when they materially improve the proposal, but
+          modify only files in the blackboard.
 
-          Reviewer completion
+          Reviewer completion:
           - fitness: ${state.fitnessDone}
           - failure: ${state.failureDone}
           - simplicity: ${state.simplicityDone}
 
-          Primary deliverable
-          design.txt is the final reader-facing Markdown design document, not a
-          scratchpad and not a transcript. On the first pass, replace the seeded
-          instructional text with the strongest useful design you can. On later
-          passes, improve it and respond inside each active review notebook to
-          every unresolved or reopened concern. Preserve accepted constraints and
-          do not disturb a reviewer that has completed.
+          design.txt is the reader-facing Markdown deliverable, not a scratchpad
+          or review transcript. On the first pass, write the strongest useful
+          proposal you can. On later passes, improve it and respond inside each
+          active review notebook to unresolved or reopened concerns. Preserve
+          accepted constraints and do not disturb a reviewer that has completed.
 
-          Reader-first document contract
-          - Write in the language of the brief unless the brief explicitly asks
-            for another language.
-          - Use progressive disclosure. Lead with the decision, expected outcome,
-            audience, and status. Explain context and alternatives before
-            implementation detail. Keep review history and exhaustive evidence
-            outside the main narrative.
-          - Preserve these exact hidden markers in design.txt so publication can
-            validate coverage: design-forge:summary, design-forge:context,
-            design-forge:options, design-forge:design,
-            design-forge:operations, design-forge:risks,
-            design-forge:delivery, and design-forge:references.
-          - State goals, non-goals, constraints, assumptions, success measures,
-            current state, and the chosen design explicitly. Define unfamiliar
-            terms and abbreviations on first use.
-          - Use compact tables for alternatives, interface inventories, risk
-            registers, rollout phases, or responsibility mappings when comparison
-            is the reader's task. Introduce every table and keep its cells concise.
-          - Give each paragraph one job. State its point early, then explain what,
-            why, and how. Remove duplicated conclusions and review chatter.
-          - Keep unresolved questions and residual risks visible without letting
-            them obscure the recommended path.
+          Use judgment rather than a fixed template. Shape the document around the
+          brief, its audience, and the actual design. Make the recommendation and
+          its consequences easy to find, then provide the context, alternatives,
+          design detail, risks, operations, validation, and delivery information
+          that this particular proposal needs. Omit sections that add no value and
+          add sections the subject genuinely requires.
 
-          Design and decision contract
-          - Maintain decision-log.md with stable D-001-style IDs for significant
-            choices. Record context, status, the selected option, rationale,
-            alternatives, consequences, and reversibility.
-          - Explain system boundaries, responsibilities, interfaces, data
-            ownership, control flow, invariants, compatibility, and operational
-            ownership at the level needed to implement and review the proposal.
-          - Cover failure modes, concurrency, recovery, security and privacy
-            boundaries, observability, testing, rollout, migration, and rollback
-            when relevant. Do not manufacture requirements absent from the brief;
-            label assumptions and open questions instead.
-          - Distinguish sourced facts from design judgments. Make the reasoning
-            chain from goals and constraints to decisions visible.
+          Optimize for reading and decision making:
+          - Prefer a clear narrative with useful headings and progressive detail.
+          - Separate facts, assumptions, decisions, trade-offs, and open questions.
+          - Explain important boundaries, responsibilities, interfaces, flows,
+            failure behavior, security concerns, and rollout implications when
+            they matter to the design.
+          - Use a compact table when comparison is easier to understand in rows and
+            columns.
+          - Add Mermaid diagrams only when a visual explains an important
+            architecture, process, interaction, lifecycle, data relationship, or
+            deployment more clearly than prose. Give each useful diagram enough
+            surrounding explanation to be understood and keep it consistent with
+            the text. Do not add decorative diagrams.
+          - Cite authoritative workspace files or public sources when they support
+            material factual claims, standards, constraints, or prior art. Use
+            normal Markdown links or a references section in whatever style best
+            fits the document. Never invent a source, and do not force citations
+            onto design judgments or common background knowledge.
+          - Keep the final document self-contained. Keep challenge history in the
+            review notebooks rather than copying it into the proposal.
 
-          Evidence and reference contract
-          - Inspect the workspace for authoritative local facts. Use available Web
-            Search or public-page reading only when an external reference
-            materially improves a factual claim, standard choice, prior-art
-            comparison, or design rationale.
-          - Never invent a URL, title, repository path, source claim, benchmark, or
-            standard. When external retrieval is unavailable, continue with
-            workspace evidence and identify the remaining evidence gap.
-          - Register every citation in references.json before using it. Preserve
-            this exact JSON shape:
-              schemaVersion: 1
-              external: entries with id, title, url, publisher, sourceType,
-              relevance, and supports
-              workspace: entries with id, path, title, relevance, and supports
-          - Use R1, R2, and so on for external entries and W1, W2, and so on for
-            workspace entries. Cite them in design.txt as [R1] or [W1]. Every
-            citation must resolve and support the adjacent claim.
-          - In the References section, list every cited ID with its title and
-            publisher plus a clickable public URL, or its repository-relative path
-            for workspace evidence. Do not register or list unused sources.
-          - Prefer primary, official, standards, research-paper, and repository
-            sources over commentary. Explain why a weaker source is still useful.
+          This is a best-effort design, not a compliance form. There is no required
+          heading list, citation notation, diagram count, decision schema, or
+          publication marker. The quality bar is that the result is useful,
+          credible, appropriately visual, and easy for its intended readers to
+          follow.
 
-          Visual communication contract
-          - Add a visual only when it reduces cognitive load for an important
-            reader question. Decorative charts are not allowed.
-          - Use a context or container view for boundaries and ownership, a
-            flowchart or sequence diagram for behavior across participants, a
-            state diagram for lifecycle rules, an entity-relationship view for
-            persistent data, and a deployment view for runtime topology. Use a
-            table instead when comparison is the actual reader task.
-          - Embed selected diagrams as Mermaid fenced blocks in design.txt and keep
-            diagram-plan.md current with the reader question, type, scope, and
-            rationale for each selected or rejected visual.
-          - Give every diagram a figure title and a one-sentence reading guide.
-            State scope and abstraction level. Name every element, label every
-            relationship with intent, define abbreviations, keep notation
-            consistent, and ensure prose and diagram describe the same design.
-          - Prefer a few high-information diagrams over many shallow ones. Do not
-            encode essential meaning only through color, shape, or layout; include
-            a concise textual fallback.
-
-          Review handling
-          - Review issues need stable IDs, explicit status, and a concrete
-            resolution in the notebook. Mark what you believe is resolved and
-            identify the corresponding document, decision, evidence, or diagram
-            change.
-          - A reviewer may reopen weak resolutions. Do not mark an issue resolved
-            merely because it was discussed.
-          - The files, not your response, are the source of truth. Return only a
-            very short note that this pass is complete.
+          The files, not your response, are the source of truth. Return only a very
+          short note that this pass is complete.
         `,
       });
 
@@ -248,63 +127,39 @@ export default defineWorkflow({
         notebook: string,
       ) => md`
         Continue as the resident ${lens} challenger.
-        Primary focus: ${focus}
+        Focus: ${focus}
 
         The Designer has completed the current pass: ${design.output}
         Work in the blackboard at ${blackboard.output.root}. Read brief.txt,
-        design.txt, references.json, decision-log.md, diagram-plan.md, and any
-        review notebook useful for context. Write only to ${notebook}; never edit
-        design.txt, a support file, or another challenger's notebook.
+        design.txt, and any review notebook useful for context. The source
+        workspace is ${meta.workspaceDir}; inspect it or relevant public sources
+        when useful. Write only to ${notebook}; never edit design.txt or another
+        challenger's notebook.
 
-        Challenge both the design and the document that communicates it.
-        design.txt is the proposed final artifact, so a sound idea hidden inside
-        an unreadable, untraceable, or misleading document is not complete.
+        Challenge both the proposal and how well design.txt communicates it, but
+        do not turn the review into a rigid compliance checklist. Concentrate on
+        consequential gaps, weak assumptions, counterexamples, misleading
+        explanations, and choices that a decision maker, implementer, operator, or
+        future maintainer could misunderstand.
 
-        Review method
-        - On your first visit, record several consequential questions,
-          counterexamples, or document defects and return done=false.
-        - Give each issue a stable lens-specific ID, severity, affected section,
-          decision or figure, concrete evidence or counterexample, required
-          change, and status. Avoid cosmetic preferences that do not affect a
-          decision, implementation, operation, or reader comprehension.
-        - On later visits, judge the response against the full current document
-          and support files. Accept adequate resolutions, reopen weak ones with
-          concrete reasons, and add another useful batch when material uncertainty
-          remains.
+        Consider whether the document makes the recommendation, rationale,
+        alternatives, trade-offs, boundaries, important failure modes, and open
+        questions clear at the depth appropriate to this brief. Also consider
+        whether a table, diagram, or reference would materially improve the
+        explanation, and whether any existing visual or citation is useful and
+        trustworthy. Do not demand a particular section, notation, source count,
+        or diagram merely for completeness.
 
-        Design checks shared by every lens
-        - Trace the proposal from goals, non-goals, constraints, and success
-          criteria through alternatives to the selected decisions.
-        - Check that consequential assumptions, interfaces, invariants, data
-          ownership, failure behavior, security boundaries, rollout, testing,
-          observability, and operational ownership are covered when relevant.
-        - Verify that decision-log.md captures significant choices and their
-          rationale, alternatives, consequences, and reversibility.
+        On your first visit, record a useful batch of the most important unresolved
+        concerns and return done=false. On later visits, judge the Designer's
+        responses against the full current design, accept adequate resolutions,
+        reopen weak ones with concrete reasons, and add new concerns only when they
+        are material. Organize the notebook however best supports the conversation.
 
-        Publication checks shared by every lens
-        - A busy reader should understand the decision and impact from the opening,
-          then move from context to detail without reading review logs.
-        - Headings, paragraphs, lists, tables, and terminology must reduce rather
-          than add cognitive load. Repeated caveats and raw challenge history
-          belong outside the main narrative.
-        - Every [R...] and [W...] citation must resolve in references.json. Reject
-          invented, irrelevant, stale, or non-supporting references and factual
-          claims presented without evidence when evidence is material.
-        - Every selected diagram must answer a named reader question, declare its
-          scope and abstraction level, name its elements, label relationship
-          intent, define notation, agree with the prose, and have a text fallback.
-          Request a missing diagram only when it communicates an important
-          boundary, behavior, lifecycle, data model, or deployment more clearly
-          than prose or a table.
-        - Open questions and residual risks must be visible and calibrated while
-          the recommended path remains unambiguous.
-
-        Completion rule
-        When your lens has no meaningful unresolved design or publication issue
-        and its important constraints are protected, record acceptance plus the
-        constraints future edits must preserve, then return done=true. Otherwise
-        return done=false. The workflow never parses the notebook, so use clear
-        plain-text organization and return only JSON matching the schema.
+        When your lens has no meaningful unresolved issue and its important
+        constraints are protected, record your acceptance and the constraints
+        future edits must preserve, then return done=true. Otherwise return
+        done=false. Return only JSON matching the schema.
       `;
 
       const challenges = step("challenge_panel").parallel({
@@ -320,7 +175,7 @@ export default defineWorkflow({
               outputSchema: Completion,
               prompt: challengePrompt(
                 "fitness",
-                "Fit to the brief, audience, current state, goals, constraints, success criteria, alternatives, decision traceability, and strength of supporting references.",
+                "Fit to the brief, audience, goals, constraints, success criteria, important alternatives, and strength of the recommendation and supporting evidence.",
                 "reviews/fitness.txt",
               ),
             }).output,
@@ -335,7 +190,7 @@ export default defineWorkflow({
               outputSchema: Completion,
               prompt: challengePrompt(
                 "failure",
-                "Counterexamples, edge cases, recovery, concurrency, security, privacy, compatibility, rollout, observability, and operational failure, including whether temporal or boundary diagrams expose risky paths.",
+                "Counterexamples, edge cases, recovery, concurrency, security, privacy, compatibility, rollout, observability, and operational failure.",
                 "reviews/failure.txt",
               ),
             }).output,
@@ -385,221 +240,14 @@ export default defineWorkflow({
     input: {
       rounds: cycle.output.rounds,
       settled,
-      workspaceDir: meta.workspaceDir,
     },
     exec: async ({ input, $, artifact }) => {
       const brief = await $`cat brief.txt`.text();
       const design = await $`cat design.txt`.text();
-      const referencesText = await $`cat references.json`.text();
-      const decisions = await $`cat decision-log.md`.text();
-      const diagramPlan = await $`cat diagram-plan.md`.text();
       const fitness = await $`cat reviews/fitness.txt`.text();
       const failure = await $`cat reviews/failure.txt`.text();
       const simplicity = await $`cat reviews/simplicity.txt`.text();
-
-      const document = design.trim();
-      if (document.length < 800 || document.includes("Replace every instructional placeholder")) {
-        throw new Error("design.txt is still an incomplete instructional draft.");
-      }
-      const sectionCount = document.split(/\r?\n/).filter(line => line.startsWith("## ")).length;
-      if (!/^#\s+\S+/m.test(document) || sectionCount < 5) {
-        throw new Error("design.txt needs a title and a scannable section hierarchy.");
-      }
-      const requiredMarkers = [
-        "summary",
-        "context",
-        "options",
-        "design",
-        "operations",
-        "risks",
-        "delivery",
-        "references",
-      ];
-      const missingMarkers = requiredMarkers.filter(marker =>
-        !document.includes(`<!-- design-forge:${marker} -->`));
-      if (missingMarkers.length) {
-        throw new Error(`design.txt is missing publication sections: ${missingMarkers.join(", ")}.`);
-      }
-
-      type ExternalReference = {
-        id: string;
-        title: string;
-        url: string;
-        publisher: string;
-        sourceType: string;
-        relevance: string;
-        supports: string;
-      };
-      type WorkspaceReference = {
-        id: string;
-        path: string;
-        title: string;
-        relevance: string;
-        supports: string;
-      };
-      type ReferenceRegistry = {
-        schemaVersion: number;
-        external: ExternalReference[];
-        workspace: WorkspaceReference[];
-      };
-
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(referencesText) as unknown;
-      } catch {
-        throw new Error("references.json must contain valid JSON.");
-      }
-      const isRecord = (value: unknown): value is Record<string, unknown> =>
-        typeof value === "object" && value !== null && !Array.isArray(value);
-      const hasText = (value: unknown): value is string =>
-        typeof value === "string" && value.trim().length > 0;
-      if (
-        !isRecord(parsed)
-        || parsed.schemaVersion !== 1
-        || !Array.isArray(parsed.external)
-        || !Array.isArray(parsed.workspace)
-      ) {
-        throw new Error("references.json does not match the design-forge reference registry.");
-      }
-
-      const ids = new Set<string>();
-      const external: ExternalReference[] = [];
-      for (const candidate of parsed.external) {
-        if (
-          !isRecord(candidate)
-          || !hasText(candidate.id)
-          || !hasText(candidate.title)
-          || !hasText(candidate.url)
-          || !hasText(candidate.publisher)
-          || !hasText(candidate.sourceType)
-          || !hasText(candidate.relevance)
-          || !hasText(candidate.supports)
-        ) {
-          throw new Error("An external reference is missing required provenance fields.");
-        }
-        if (!/^R[1-9]\d*$/.test(candidate.id) || ids.has(candidate.id)) {
-          throw new Error(`Invalid or duplicate external reference ID '${candidate.id}'.`);
-        }
-        let protocol = "";
-        try {
-          protocol = new URL(candidate.url).protocol;
-        } catch {
-          throw new Error(`External reference '${candidate.id}' has an invalid URL.`);
-        }
-        if (protocol !== "http:" && protocol !== "https:") {
-          throw new Error(`External reference '${candidate.id}' must use public HTTP(S).`);
-        }
-        ids.add(candidate.id);
-        external.push({
-          id: candidate.id,
-          title: candidate.title,
-          url: candidate.url,
-          publisher: candidate.publisher,
-          sourceType: candidate.sourceType,
-          relevance: candidate.relevance,
-          supports: candidate.supports,
-        });
-      }
-
-      const workspace: WorkspaceReference[] = [];
-      for (const candidate of parsed.workspace) {
-        if (
-          !isRecord(candidate)
-          || !hasText(candidate.id)
-          || !hasText(candidate.path)
-          || !hasText(candidate.title)
-          || !hasText(candidate.relevance)
-          || !hasText(candidate.supports)
-        ) {
-          throw new Error("A workspace reference is missing required provenance fields.");
-        }
-        const path = candidate.path.trim().replaceAll("\\", "/");
-        if (
-          !/^W[1-9]\d*$/.test(candidate.id)
-          || ids.has(candidate.id)
-          || path.startsWith("/")
-          || path.split("/").includes("..")
-        ) {
-          throw new Error(`Workspace reference '${candidate.id}' is invalid or unsafe.`);
-        }
-        const existing = await $`test -e ${`${input.workspaceDir}/${path}`}`.nothrow();
-        if (existing.exitCode !== 0) {
-          throw new Error(`Workspace reference '${candidate.id}' points to a missing path.`);
-        }
-        ids.add(candidate.id);
-        workspace.push({
-          id: candidate.id,
-          path,
-          title: candidate.title,
-          relevance: candidate.relevance,
-          supports: candidate.supports,
-        });
-      }
-      const references: ReferenceRegistry = {
-        schemaVersion: 1,
-        external,
-        workspace,
-      };
-
-      const cited = [...document.matchAll(/\[((?:R|W)[1-9]\d*)\]/g)]
-        .flatMap(match => match[1] === undefined ? [] : [match[1]]);
-      const citedIds = new Set(cited);
-      const unresolvedCitations = [...citedIds].filter(id => !ids.has(id));
-      if (unresolvedCitations.length) {
-        throw new Error(`design.txt cites unknown references: ${unresolvedCitations.join(", ")}.`);
-      }
-      const unusedReferences = [...ids].filter(id => !citedIds.has(id));
-      if (unusedReferences.length) {
-        throw new Error(`references.json contains unused sources: ${unusedReferences.join(", ")}.`);
-      }
-      for (const source of external) {
-        if (!document.includes(source.url)) {
-          throw new Error(`The References section must link external source '${source.id}'.`);
-        }
-      }
-      for (const source of workspace) {
-        if (!document.includes(source.path)) {
-          throw new Error(`The References section must name workspace source '${source.id}'.`);
-        }
-      }
-      if (document.includes("file://")) {
-        throw new Error("design.txt must not publish file:// links.");
-      }
-
-      const lines = document.split(/\r?\n/);
-      let inMermaid = false;
-      let mermaidLines = 0;
-      let mermaidCount = 0;
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!inMermaid && trimmed === "```mermaid") {
-          inMermaid = true;
-          mermaidLines = 0;
-          mermaidCount += 1;
-          continue;
-        }
-        if (inMermaid && trimmed === "```") {
-          if (mermaidLines < 2) {
-            throw new Error("A Mermaid diagram is empty or uninformative.");
-          }
-          inMermaid = false;
-          continue;
-        }
-        if (inMermaid && trimmed) mermaidLines += 1;
-      }
-      if (inMermaid) throw new Error("design.txt has an unclosed Mermaid fence.");
-
-      const outcome = input.settled ? "consensus" : "round-limit";
-      const markdown = [
-        "---",
-        `design_forge_outcome: ${outcome}`,
-        `design_forge_rounds: ${input.rounds}`,
-        `design_forge_diagrams: ${mermaidCount}`,
-        "---",
-        "",
-        document,
-        "",
-      ].join("\n");
+      const outcome = input.settled ? "consensus" : "round limit";
       const reviewLog = [
         "DESIGN FORGE REVIEW LOG",
         `Outcome: ${outcome}`,
@@ -607,12 +255,6 @@ export default defineWorkflow({
         "",
         "===== BRIEF =====",
         brief.trimEnd(),
-        "",
-        "===== DECISION LOG =====",
-        decisions.trimEnd(),
-        "",
-        "===== DIAGRAM PLAN =====",
-        diagramPlan.trimEnd(),
         "",
         "===== FITNESS REVIEW =====",
         fitness.trimEnd(),
@@ -624,32 +266,11 @@ export default defineWorkflow({
         simplicity.trimEnd(),
         "",
       ].join("\n");
-      const designPackage = {
-        schemaVersion: 1,
-        outcome,
-        rounds: input.rounds,
-        diagramCount: mermaidCount,
-        brief: brief.trimEnd(),
-        document,
-        references,
-        decisionLog: decisions.trimEnd(),
-        diagramPlan: diagramPlan.trimEnd(),
-        reviews: {
-          fitness: fitness.trimEnd(),
-          failure: failure.trimEnd(),
-          simplicity: simplicity.trimEnd(),
-        },
-      };
 
       const blackboard = await artifact.write(
         "design-forge.md",
-        markdown,
+        `${design.trimEnd()}\n`,
         { mediaType: "text/markdown" },
-      );
-      await artifact.write(
-        "design-forge-package.json",
-        JSON.stringify(designPackage, null, 2),
-        { mediaType: "application/json" },
       );
       await artifact.write(
         "design-forge-review-log.txt",

--- a/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
+++ b/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
@@ -542,7 +542,8 @@ export default defineWorkflow({
         workspace,
       };
 
-      const cited = [...document.matchAll(/\[((?:R|W)[1-9]\d*)\]/g)].map(match => match[1]);
+      const cited = [...document.matchAll(/\[((?:R|W)[1-9]\d*)\]/g)]
+        .flatMap(match => match[1] === undefined ? [] : [match[1]]);
       const citedIds = new Set(cited);
       const unresolvedCitations = [...citedIds].filter(id => !ids.has(id));
       if (unresolvedCitations.length) {

--- a/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
+++ b/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
@@ -1,6 +1,7 @@
 /*
- * Pattern: Develop one design through three resident challenge conversations
- * sharing a run-scoped plain-text blackboard.
+ * Pattern: Develop one reader-facing design through three resident challenge
+ * conversations sharing a run-scoped blackboard, then publish the design and a
+ * separate audit package.
  * Scale: at most maxRounds × (1 designer + 3 challengers); peak ready Agents: 3.
  * Nodes: agent, task, if, parallel, loop
  */
@@ -13,10 +14,10 @@ const Completion = z.object({
 
 export default defineWorkflow({
   name: "design-forge",
-  description: "Develop a decision-ready design through resident challenges on a shared text blackboard.",
+  description: "Develop and publish a decision-ready Markdown design through resident challenges on a shared blackboard.",
   inputSchema: z.object({
     brief: z.string().describe(
-      "The problem, goals, constraints, and success criteria for the design.",
+      "The problem, audience, goals, constraints, success criteria, and any known references for the design.",
     ),
     maxRounds: z.number().int().positive().default(5).describe(
       "Maximum number of design and challenge rounds.",
@@ -39,10 +40,73 @@ export default defineWorkflow({
         if (existing.exitCode !== 0) await $`printf %s ${content} > ${path}`;
       };
 
+      const designTemplate = [
+        "# Design proposal",
+        "",
+        "> Status: Draft. Replace every instructional placeholder before publication.",
+        "",
+        "<!-- design-forge:summary -->",
+        "## Decision at a glance",
+        "Explain the recommendation, its audience, and the outcome it enables.",
+        "",
+        "<!-- design-forge:context -->",
+        "## Context, scope, and success criteria",
+        "Explain the current state, goals, non-goals, constraints, assumptions, and measurable success criteria.",
+        "",
+        "<!-- design-forge:options -->",
+        "## Options and decision",
+        "Compare credible alternatives, then explain the selected option and its consequences.",
+        "",
+        "<!-- design-forge:design -->",
+        "## Proposed design",
+        "Describe boundaries, responsibilities, interfaces, data, control flow, and selected diagrams.",
+        "",
+        "<!-- design-forge:operations -->",
+        "## Reliability, security, and operations",
+        "Cover failure behavior, recovery, security boundaries, observability, and the operating model.",
+        "",
+        "<!-- design-forge:risks -->",
+        "## Risks, assumptions, and open questions",
+        "Distinguish accepted trade-offs from unresolved questions and residual risks.",
+        "",
+        "<!-- design-forge:delivery -->",
+        "## Delivery and validation",
+        "Describe rollout, migration, testing, compatibility, ownership, and rollback.",
+        "",
+        "<!-- design-forge:references -->",
+        "## References",
+        "List only sources registered in references.json and cite them by stable ID.",
+        "",
+      ].join("\n");
+      const referenceTemplate = `${JSON.stringify({
+        schemaVersion: 1,
+        external: [],
+        workspace: [],
+      }, null, 2)}\n`;
+      const decisionTemplate = [
+        "# Decision log",
+        "",
+        "Track architecturally significant choices with stable IDs such as D-001.",
+        "",
+        "| ID | Status | Decision | Context and rationale | Alternatives | Consequences and reversibility |",
+        "| --- | --- | --- | --- | --- | --- |",
+        "",
+      ].join("\n");
+      const diagramTemplate = [
+        "# Diagram plan",
+        "",
+        "For every selected or rejected visual, record the reader question, diagram type, scope, and rationale.",
+        "A diagram is optional when prose or a compact table communicates the design more clearly.",
+        "",
+      ].join("\n");
+
       await $`mkdir -p ${`${root}/reviews`}`;
       await $`chmod 700 ${root}`;
       await writeOnce(`${root}/brief.txt`, `${input.brief}\n`);
-      await writeOnce(`${root}/design.txt`, "No design has been written yet.\n");
+      await writeOnce(`${root}/design.txt`, designTemplate);
+      await writeOnce(`${root}/references.json`, referenceTemplate);
+      await writeOnce(`${root}/decision-log.md`, decisionTemplate);
+      await writeOnce(`${root}/diagram-plan.md`, diagramTemplate);
       await writeOnce(`${root}/reviews/fitness.txt`, "No fitness review has been recorded yet.\n");
       await writeOnce(`${root}/reviews/failure.txt`, "No failure review has been recorded yet.\n");
       await writeOnce(`${root}/reviews/simplicity.txt`, "No simplicity review has been recorded yet.\n");
@@ -62,26 +126,119 @@ export default defineWorkflow({
         agent: agents.designer,
         cwd: blackboard.output.root,
         prompt: md`
-          Work directly in the plain-text blackboard at
-          ${blackboard.output.root}. Read brief.txt, design.txt, and the three
-          files under reviews/. The source workspace is ${meta.workspaceDir};
-          inspect it when useful, but modify only files in the blackboard.
+          Role
+          You are the design owner and publication author. Develop the design and
+          maintain one reader-facing Markdown document that a decision maker,
+          implementer, operator, and future maintainer can understand without
+          reading the review notebooks.
 
-          Reviewer completion:
+          Blackboard
+          Work directly in ${blackboard.output.root}. Read brief.txt, design.txt,
+          references.json, decision-log.md, diagram-plan.md, and all three files
+          under reviews/. The source workspace is ${meta.workspaceDir}; inspect it
+          when useful, but modify only files in the blackboard.
+
+          Reviewer completion
           - fitness: ${state.fitnessDone}
           - failure: ${state.failureDone}
           - simplicity: ${state.simplicityDone}
 
-          On the first pass, create the strongest useful design you can in
-          design.txt. On later passes, improve it and respond inside the review
-          notebooks to every unresolved or reopened concern. Mark what you
-          believe is resolved, preserve useful history and accepted constraints,
-          and do not disturb a reviewer that has completed.
+          Primary deliverable
+          design.txt is the final reader-facing Markdown design document, not a
+          scratchpad and not a transcript. On the first pass, replace the seeded
+          instructional text with the strongest useful design you can. On later
+          passes, improve it and respond inside each active review notebook to
+          every unresolved or reopened concern. Preserve accepted constraints and
+          do not disturb a reviewer that has completed.
 
-          There is no required notation or document template. Organize and
-          rewrite the text however best supports the reasoning. The files, not
-          your response, are the source of truth. Return only a very short note
-          that this pass is complete.
+          Reader-first document contract
+          - Write in the language of the brief unless the brief explicitly asks
+            for another language.
+          - Use progressive disclosure. Lead with the decision, expected outcome,
+            audience, and status. Explain context and alternatives before
+            implementation detail. Keep review history and exhaustive evidence
+            outside the main narrative.
+          - Preserve these exact hidden markers in design.txt so publication can
+            validate coverage: design-forge:summary, design-forge:context,
+            design-forge:options, design-forge:design,
+            design-forge:operations, design-forge:risks,
+            design-forge:delivery, and design-forge:references.
+          - State goals, non-goals, constraints, assumptions, success measures,
+            current state, and the chosen design explicitly. Define unfamiliar
+            terms and abbreviations on first use.
+          - Use compact tables for alternatives, interface inventories, risk
+            registers, rollout phases, or responsibility mappings when comparison
+            is the reader's task. Introduce every table and keep its cells concise.
+          - Give each paragraph one job. State its point early, then explain what,
+            why, and how. Remove duplicated conclusions and review chatter.
+          - Keep unresolved questions and residual risks visible without letting
+            them obscure the recommended path.
+
+          Design and decision contract
+          - Maintain decision-log.md with stable D-001-style IDs for significant
+            choices. Record context, status, the selected option, rationale,
+            alternatives, consequences, and reversibility.
+          - Explain system boundaries, responsibilities, interfaces, data
+            ownership, control flow, invariants, compatibility, and operational
+            ownership at the level needed to implement and review the proposal.
+          - Cover failure modes, concurrency, recovery, security and privacy
+            boundaries, observability, testing, rollout, migration, and rollback
+            when relevant. Do not manufacture requirements absent from the brief;
+            label assumptions and open questions instead.
+          - Distinguish sourced facts from design judgments. Make the reasoning
+            chain from goals and constraints to decisions visible.
+
+          Evidence and reference contract
+          - Inspect the workspace for authoritative local facts. Use available Web
+            Search or public-page reading only when an external reference
+            materially improves a factual claim, standard choice, prior-art
+            comparison, or design rationale.
+          - Never invent a URL, title, repository path, source claim, benchmark, or
+            standard. When external retrieval is unavailable, continue with
+            workspace evidence and identify the remaining evidence gap.
+          - Register every citation in references.json before using it. Preserve
+            this exact JSON shape:
+              schemaVersion: 1
+              external: entries with id, title, url, publisher, sourceType,
+              relevance, and supports
+              workspace: entries with id, path, title, relevance, and supports
+          - Use R1, R2, and so on for external entries and W1, W2, and so on for
+            workspace entries. Cite them in design.txt as [R1] or [W1]. Every
+            citation must resolve and support the adjacent claim.
+          - In the References section, list every cited ID with its title and
+            publisher plus a clickable public URL, or its repository-relative path
+            for workspace evidence. Do not register or list unused sources.
+          - Prefer primary, official, standards, research-paper, and repository
+            sources over commentary. Explain why a weaker source is still useful.
+
+          Visual communication contract
+          - Add a visual only when it reduces cognitive load for an important
+            reader question. Decorative charts are not allowed.
+          - Use a context or container view for boundaries and ownership, a
+            flowchart or sequence diagram for behavior across participants, a
+            state diagram for lifecycle rules, an entity-relationship view for
+            persistent data, and a deployment view for runtime topology. Use a
+            table instead when comparison is the actual reader task.
+          - Embed selected diagrams as Mermaid fenced blocks in design.txt and keep
+            diagram-plan.md current with the reader question, type, scope, and
+            rationale for each selected or rejected visual.
+          - Give every diagram a figure title and a one-sentence reading guide.
+            State scope and abstraction level. Name every element, label every
+            relationship with intent, define abbreviations, keep notation
+            consistent, and ensure prose and diagram describe the same design.
+          - Prefer a few high-information diagrams over many shallow ones. Do not
+            encode essential meaning only through color, shape, or layout; include
+            a concise textual fallback.
+
+          Review handling
+          - Review issues need stable IDs, explicit status, and a concrete
+            resolution in the notebook. Mark what you believe is resolved and
+            identify the corresponding document, decision, evidence, or diagram
+            change.
+          - A reviewer may reopen weak resolutions. Do not mark an issue resolved
+            merely because it was discussed.
+          - The files, not your response, are the source of truth. Return only a
+            very short note that this pass is complete.
         `,
       });
 
@@ -91,24 +248,63 @@ export default defineWorkflow({
         notebook: string,
       ) => md`
         Continue as the resident ${lens} challenger.
-        Focus: ${focus}
+        Primary focus: ${focus}
 
         The Designer has completed the current pass: ${design.output}
         Work in the blackboard at ${blackboard.output.root}. Read brief.txt,
-        design.txt, and any review notebook useful for context. Write only to
-        ${notebook}; never edit design.txt or another challenger's notebook.
+        design.txt, references.json, decision-log.md, diagram-plan.md, and any
+        review notebook useful for context. Write only to ${notebook}; never edit
+        design.txt, a support file, or another challenger's notebook.
 
-        On your first visit, record several consequential questions or
-        counterexamples, make it clear that they remain unresolved, and return
-        done=false. On later visits, judge the Designer's responses using the
-        full design: accept adequate resolutions, reopen weak ones with concrete
-        reasons, and add another useful batch when material uncertainty remains.
+        Challenge both the design and the document that communicates it.
+        design.txt is the proposed final artifact, so a sound idea hidden inside
+        an unreadable, untraceable, or misleading document is not complete.
 
-        When your lens has no meaningful unresolved issue and its important
-        constraints are protected, record your acceptance and the constraints
-        future edits must preserve, then return done=true. Otherwise return
-        done=false. Use whatever plain-text organization best supports your
-        reasoning; the workflow never parses the notebook.
+        Review method
+        - On your first visit, record several consequential questions,
+          counterexamples, or document defects and return done=false.
+        - Give each issue a stable lens-specific ID, severity, affected section,
+          decision or figure, concrete evidence or counterexample, required
+          change, and status. Avoid cosmetic preferences that do not affect a
+          decision, implementation, operation, or reader comprehension.
+        - On later visits, judge the response against the full current document
+          and support files. Accept adequate resolutions, reopen weak ones with
+          concrete reasons, and add another useful batch when material uncertainty
+          remains.
+
+        Design checks shared by every lens
+        - Trace the proposal from goals, non-goals, constraints, and success
+          criteria through alternatives to the selected decisions.
+        - Check that consequential assumptions, interfaces, invariants, data
+          ownership, failure behavior, security boundaries, rollout, testing,
+          observability, and operational ownership are covered when relevant.
+        - Verify that decision-log.md captures significant choices and their
+          rationale, alternatives, consequences, and reversibility.
+
+        Publication checks shared by every lens
+        - A busy reader should understand the decision and impact from the opening,
+          then move from context to detail without reading review logs.
+        - Headings, paragraphs, lists, tables, and terminology must reduce rather
+          than add cognitive load. Repeated caveats and raw challenge history
+          belong outside the main narrative.
+        - Every [R...] and [W...] citation must resolve in references.json. Reject
+          invented, irrelevant, stale, or non-supporting references and factual
+          claims presented without evidence when evidence is material.
+        - Every selected diagram must answer a named reader question, declare its
+          scope and abstraction level, name its elements, label relationship
+          intent, define notation, agree with the prose, and have a text fallback.
+          Request a missing diagram only when it communicates an important
+          boundary, behavior, lifecycle, data model, or deployment more clearly
+          than prose or a table.
+        - Open questions and residual risks must be visible and calibrated while
+          the recommended path remains unambiguous.
+
+        Completion rule
+        When your lens has no meaningful unresolved design or publication issue
+        and its important constraints are protected, record acceptance plus the
+        constraints future edits must preserve, then return done=true. Otherwise
+        return done=false. The workflow never parses the notebook, so use clear
+        plain-text organization and return only JSON matching the schema.
       `;
 
       const challenges = step("challenge_panel").parallel({
@@ -124,7 +320,7 @@ export default defineWorkflow({
               outputSchema: Completion,
               prompt: challengePrompt(
                 "fitness",
-                "Fit to the brief, goals, constraints, success criteria, users, and important alternatives.",
+                "Fit to the brief, audience, current state, goals, constraints, success criteria, alternatives, decision traceability, and strength of supporting references.",
                 "reviews/fitness.txt",
               ),
             }).output,
@@ -139,7 +335,7 @@ export default defineWorkflow({
               outputSchema: Completion,
               prompt: challengePrompt(
                 "failure",
-                "Counterexamples, edge cases, recovery, concurrency, security, and operational failure.",
+                "Counterexamples, edge cases, recovery, concurrency, security, privacy, compatibility, rollout, observability, and operational failure, including whether temporal or boundary diagrams expose risky paths.",
                 "reviews/failure.txt",
               ),
             }).output,
@@ -154,7 +350,7 @@ export default defineWorkflow({
               outputSchema: Completion,
               prompt: challengePrompt(
                 "simplicity",
-                "Unnecessary complexity, coupling, cheaper approaches, testability, comprehension, and operation.",
+                "Unnecessary complexity, coupling, cheaper approaches, testability, operability, document hierarchy, terminology, duplication, and whether every table or diagram earns its cognitive cost.",
                 "reviews/simplicity.txt",
               ),
             }).output,
@@ -189,25 +385,234 @@ export default defineWorkflow({
     input: {
       rounds: cycle.output.rounds,
       settled,
+      workspaceDir: meta.workspaceDir,
     },
     exec: async ({ input, $, artifact }) => {
-      const [brief, design, fitness, failure, simplicity] = await Promise.all([
+      const [brief, design, referencesText, decisions, diagramPlan, fitness, failure, simplicity] = await Promise.all([
         $`cat brief.txt`.text(),
         $`cat design.txt`.text(),
+        $`cat references.json`.text(),
+        $`cat decision-log.md`.text(),
+        $`cat diagram-plan.md`.text(),
         $`cat reviews/fitness.txt`.text(),
         $`cat reviews/failure.txt`.text(),
         $`cat reviews/simplicity.txt`.text(),
       ]);
-      const content = [
-        "DESIGN FORGE",
-        `Outcome: ${input.settled ? "consensus" : "round limit"}`,
+
+      const document = design.trim();
+      if (document.length < 800 || document.includes("Replace every instructional placeholder")) {
+        throw new Error("design.txt is still an incomplete instructional draft.");
+      }
+      if (!/^#\s+\S+/m.test(document) || (document.match(/^##\s+/gm) ?? []).length < 5) {
+        throw new Error("design.txt needs a title and a scannable section hierarchy.");
+      }
+      const requiredMarkers = [
+        "summary",
+        "context",
+        "options",
+        "design",
+        "operations",
+        "risks",
+        "delivery",
+        "references",
+      ];
+      const missingMarkers = requiredMarkers.filter(marker =>
+        !document.includes(`<!-- design-forge:${marker} -->`));
+      if (missingMarkers.length) {
+        throw new Error(`design.txt is missing publication sections: ${missingMarkers.join(", ")}.`);
+      }
+
+      type ExternalReference = {
+        id: string;
+        title: string;
+        url: string;
+        publisher: string;
+        sourceType: string;
+        relevance: string;
+        supports: string;
+      };
+      type WorkspaceReference = {
+        id: string;
+        path: string;
+        title: string;
+        relevance: string;
+        supports: string;
+      };
+      type ReferenceRegistry = {
+        schemaVersion: number;
+        external: ExternalReference[];
+        workspace: WorkspaceReference[];
+      };
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(referencesText) as unknown;
+      } catch {
+        throw new Error("references.json must contain valid JSON.");
+      }
+      const isRecord = (value: unknown): value is Record<string, unknown> =>
+        typeof value === "object" && value !== null && !Array.isArray(value);
+      const hasText = (value: unknown): value is string =>
+        typeof value === "string" && value.trim().length > 0;
+      if (
+        !isRecord(parsed)
+        || parsed.schemaVersion !== 1
+        || !Array.isArray(parsed.external)
+        || !Array.isArray(parsed.workspace)
+      ) {
+        throw new Error("references.json does not match the design-forge reference registry.");
+      }
+
+      const ids = new Set<string>();
+      const external: ExternalReference[] = [];
+      for (const candidate of parsed.external) {
+        if (
+          !isRecord(candidate)
+          || !hasText(candidate.id)
+          || !hasText(candidate.title)
+          || !hasText(candidate.url)
+          || !hasText(candidate.publisher)
+          || !hasText(candidate.sourceType)
+          || !hasText(candidate.relevance)
+          || !hasText(candidate.supports)
+        ) {
+          throw new Error("An external reference is missing required provenance fields.");
+        }
+        if (!/^R[1-9]\d*$/.test(candidate.id) || ids.has(candidate.id)) {
+          throw new Error(`Invalid or duplicate external reference ID '${candidate.id}'.`);
+        }
+        let protocol = "";
+        try {
+          protocol = new URL(candidate.url).protocol;
+        } catch {
+          throw new Error(`External reference '${candidate.id}' has an invalid URL.`);
+        }
+        if (protocol !== "http:" && protocol !== "https:") {
+          throw new Error(`External reference '${candidate.id}' must use public HTTP(S).`);
+        }
+        ids.add(candidate.id);
+        external.push({
+          id: candidate.id,
+          title: candidate.title,
+          url: candidate.url,
+          publisher: candidate.publisher,
+          sourceType: candidate.sourceType,
+          relevance: candidate.relevance,
+          supports: candidate.supports,
+        });
+      }
+
+      const workspace: WorkspaceReference[] = [];
+      for (const candidate of parsed.workspace) {
+        if (
+          !isRecord(candidate)
+          || !hasText(candidate.id)
+          || !hasText(candidate.path)
+          || !hasText(candidate.title)
+          || !hasText(candidate.relevance)
+          || !hasText(candidate.supports)
+        ) {
+          throw new Error("A workspace reference is missing required provenance fields.");
+        }
+        const path = candidate.path.trim().replaceAll("\\", "/");
+        if (
+          !/^W[1-9]\d*$/.test(candidate.id)
+          || ids.has(candidate.id)
+          || path.startsWith("/")
+          || path.split("/").includes("..")
+        ) {
+          throw new Error(`Workspace reference '${candidate.id}' is invalid or unsafe.`);
+        }
+        const existing = await $`test -e ${`${input.workspaceDir}/${path}`}`.nothrow();
+        if (existing.exitCode !== 0) {
+          throw new Error(`Workspace reference '${candidate.id}' points to a missing path.`);
+        }
+        ids.add(candidate.id);
+        workspace.push({
+          id: candidate.id,
+          path,
+          title: candidate.title,
+          relevance: candidate.relevance,
+          supports: candidate.supports,
+        });
+      }
+      const references: ReferenceRegistry = {
+        schemaVersion: 1,
+        external,
+        workspace,
+      };
+
+      const cited = [...document.matchAll(/\[((?:R|W)[1-9]\d*)\]/g)].map(match => match[1]);
+      const citedIds = new Set(cited);
+      const unresolvedCitations = [...citedIds].filter(id => !ids.has(id));
+      if (unresolvedCitations.length) {
+        throw new Error(`design.txt cites unknown references: ${unresolvedCitations.join(", ")}.`);
+      }
+      const unusedReferences = [...ids].filter(id => !citedIds.has(id));
+      if (unusedReferences.length) {
+        throw new Error(`references.json contains unused sources: ${unusedReferences.join(", ")}.`);
+      }
+      for (const source of external) {
+        if (!document.includes(source.url)) {
+          throw new Error(`The References section must link external source '${source.id}'.`);
+        }
+      }
+      for (const source of workspace) {
+        if (!document.includes(source.path)) {
+          throw new Error(`The References section must name workspace source '${source.id}'.`);
+        }
+      }
+      if (document.includes("file://")) {
+        throw new Error("design.txt must not publish file:// links.");
+      }
+
+      const lines = document.split(/\r?\n/);
+      let inMermaid = false;
+      let mermaidLines = 0;
+      let mermaidCount = 0;
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!inMermaid && trimmed === "```mermaid") {
+          inMermaid = true;
+          mermaidLines = 0;
+          mermaidCount += 1;
+          continue;
+        }
+        if (inMermaid && trimmed === "```") {
+          if (mermaidLines < 2) {
+            throw new Error("A Mermaid diagram is empty or uninformative.");
+          }
+          inMermaid = false;
+          continue;
+        }
+        if (inMermaid && trimmed) mermaidLines += 1;
+      }
+      if (inMermaid) throw new Error("design.txt has an unclosed Mermaid fence.");
+
+      const outcome = input.settled ? "consensus" : "round-limit";
+      const markdown = [
+        "---",
+        `design_forge_outcome: ${outcome}`,
+        `design_forge_rounds: ${input.rounds}`,
+        `design_forge_diagrams: ${mermaidCount}`,
+        "---",
+        "",
+        document,
+        "",
+      ].join("\n");
+      const reviewLog = [
+        "DESIGN FORGE REVIEW LOG",
+        `Outcome: ${outcome}`,
         `Rounds: ${input.rounds}`,
         "",
         "===== BRIEF =====",
         brief.trimEnd(),
         "",
-        "===== DESIGN =====",
-        design.trimEnd(),
+        "===== DECISION LOG =====",
+        decisions.trimEnd(),
+        "",
+        "===== DIAGRAM PLAN =====",
+        diagramPlan.trimEnd(),
         "",
         "===== FITNESS REVIEW =====",
         fitness.trimEnd(),
@@ -219,13 +624,39 @@ export default defineWorkflow({
         simplicity.trimEnd(),
         "",
       ].join("\n");
-      return {
-        blackboard: await artifact.write(
-          "design-forge.txt",
-          content,
-          { mediaType: "text/plain" },
-        ),
+      const designPackage = {
+        schemaVersion: 1,
+        outcome,
+        rounds: input.rounds,
+        diagramCount: mermaidCount,
+        brief: brief.trimEnd(),
+        document,
+        references,
+        decisionLog: decisions.trimEnd(),
+        diagramPlan: diagramPlan.trimEnd(),
+        reviews: {
+          fitness: fitness.trimEnd(),
+          failure: failure.trimEnd(),
+          simplicity: simplicity.trimEnd(),
+        },
       };
+
+      const blackboard = await artifact.write(
+        "design-forge.md",
+        markdown,
+        { mediaType: "text/markdown" },
+      );
+      await artifact.write(
+        "design-forge-package.json",
+        JSON.stringify(designPackage, null, 2),
+        { mediaType: "application/json" },
+      );
+      await artifact.write(
+        "design-forge-review-log.txt",
+        reviewLog,
+        { mediaType: "text/plain" },
+      );
+      return { blackboard };
     },
   });
 

--- a/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
+++ b/packages/cli/skills/acpus/workflows/examples/design-forge/workflow.ts
@@ -401,7 +401,8 @@ export default defineWorkflow({
       if (document.length < 800 || document.includes("Replace every instructional placeholder")) {
         throw new Error("design.txt is still an incomplete instructional draft.");
       }
-      if (!/^#\s+\S+/m.test(document) || (document.match(/^##\s+/gm) ?? []).length < 5) {
+      const sectionCount = document.split(/\r?\n/).filter(line => line.startsWith("## ")).length;
+      if (!/^#\s+\S+/m.test(document) || sectionCount < 5) {
         throw new Error("design.txt needs a title and a scannable section hierarchy.");
       }
       const requiredMarkers = [

--- a/packages/cli/test/design-forge-publication.contract.test.ts
+++ b/packages/cli/test/design-forge-publication.contract.test.ts
@@ -12,7 +12,7 @@ describe("design-forge publication contract", () => {
     expect(source).toContain('{ mediaType: "application/json" }');
     expect(source).toContain('"design-forge-review-log.txt"');
     expect(source).toContain('{ mediaType: "text/plain" }');
-    expect(source).toContain("not a scratchpad and not a transcript");
+    expect(source).toMatch(/not a\s+scratchpad and not a transcript/);
   });
 
   it("grounds the publication in structured decisions, references, and useful diagrams", async () => {

--- a/packages/cli/test/design-forge-publication.contract.test.ts
+++ b/packages/cli/test/design-forge-publication.contract.test.ts
@@ -3,39 +3,48 @@ import { describe, expect, it } from "vitest";
 import { skillExampleWorkflowPath } from "./support/skill-workflow-examples.js";
 
 describe("design-forge publication contract", () => {
-  it("publishes a reader-facing Markdown design separately from the audit trail", async () => {
+  it("publishes the Agent-authored Markdown separately from review history", async () => {
     const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
 
     expect(source).toContain('"design-forge.md"');
     expect(source).toContain('{ mediaType: "text/markdown" }');
-    expect(source).toContain('"design-forge-package.json"');
-    expect(source).toContain('{ mediaType: "application/json" }');
     expect(source).toContain('"design-forge-review-log.txt"');
     expect(source).toContain('{ mediaType: "text/plain" }');
-    expect(source).toMatch(/not a\s+scratchpad and not a transcript/);
+    expect(source).toMatch(/reader-facing Markdown deliverable, not a\s+scratchpad/);
+    expect(source).not.toContain('"design-forge-package.json"');
   });
 
-  it("grounds the publication in structured decisions, references, and useful diagrams", async () => {
+  it("keeps document structure, references, and visuals under Agent judgment", async () => {
     const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
 
-    for (const file of ["references.json", "decision-log.md", "diagram-plan.md"]) {
-      expect(source).toContain(file);
-    }
-    for (const marker of [
-      "summary",
-      "context",
-      "options",
-      "design",
-      "operations",
-      "risks",
-      "delivery",
-      "references",
+    expect(source).toContain("Use judgment rather than a fixed template");
+    expect(source).toMatch(/There is no required\s+heading list, citation notation, diagram count, decision schema, or\s+publication marker/);
+    expect(source).toMatch(/Add Mermaid diagrams only when a visual explains/);
+    expect(source).toMatch(/Cite authoritative workspace files or public sources when they support/);
+    expect(source).toContain("do not turn the review into a rigid compliance checklist");
+
+    for (const rigidResource of [
+      "references.json",
+      "decision-log.md",
+      "diagram-plan.md",
+      "design-forge:summary",
     ]) {
-      expect(source).toContain(`design-forge:${marker}`);
+      expect(source).not.toContain(rigidResource);
     }
-    expect(source).toContain("new URL(candidate.url).protocol");
-    expect(source).toContain("points to a missing path");
-    expect(source).toContain('trimmed === "```mermaid"');
-    expect(source).toContain("contains unused sources");
+  });
+
+  it("keeps Tasks limited to small blackboard and artifact operations", async () => {
+    const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
+    const publishStart = source.indexOf('const published = step("publish_blackboard")');
+
+    expect(publishStart).toBeGreaterThan(0);
+    expect(source.match(/\.task\(\{/g) ?? []).toHaveLength(2);
+
+    const publishSource = source.slice(publishStart);
+    expect(publishSource).toContain("artifact.write");
+    expect(publishSource).not.toContain("throw new Error");
+    expect(publishSource).not.toContain("JSON.parse");
+    expect(publishSource).not.toContain("requiredMarkers");
+    expect(publishSource).not.toContain("matchAll");
   });
 });

--- a/packages/cli/test/design-forge-publication.contract.test.ts
+++ b/packages/cli/test/design-forge-publication.contract.test.ts
@@ -10,32 +10,27 @@ describe("design-forge publication contract", () => {
     expect(source).toContain('{ mediaType: "text/markdown" }');
     expect(source).toContain('"design-forge-review-log.txt"');
     expect(source).toContain('{ mediaType: "text/plain" }');
-    expect(source).toMatch(/reader-facing Markdown deliverable, not a\s+scratchpad/);
     expect(source).not.toContain('"design-forge-package.json"');
   });
 
-  it("keeps document structure, references, and visuals under Agent judgment", async () => {
+  it("keeps editorial choices with Agents and Tasks mechanically small", async () => {
     const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
+    const publishStart = source.indexOf('const published = step("publish_blackboard")');
 
-    expect(source).toContain("Use judgment rather than a fixed template");
-    expect(source).toMatch(/There is no required\s+heading list, citation notation, diagram count, decision schema, or\s+publication marker/);
-    expect(source).toMatch(/Add Mermaid diagrams only when a visual explains/);
-    expect(source).toMatch(/Cite authoritative workspace files or public sources when they support/);
-    expect(source).toContain("do not turn the review into a rigid compliance checklist");
+    expect(source).toMatch(/fixed template/i);
+    expect(source).toMatch(/best-effort/i);
+    expect(source).toMatch(/Mermaid diagrams/i);
+    expect(source).toMatch(/public sources/i);
 
-    for (const rigidResource of [
+    for (const rigidMechanism of [
       "references.json",
       "decision-log.md",
       "diagram-plan.md",
       "design-forge:summary",
+      "requiredMarkers",
     ]) {
-      expect(source).not.toContain(rigidResource);
+      expect(source).not.toContain(rigidMechanism);
     }
-  });
-
-  it("keeps Tasks limited to small blackboard and artifact operations", async () => {
-    const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
-    const publishStart = source.indexOf('const published = step("publish_blackboard")');
 
     expect(publishStart).toBeGreaterThan(0);
     expect(source.match(/\.task\(\{/g) ?? []).toHaveLength(2);
@@ -44,7 +39,6 @@ describe("design-forge publication contract", () => {
     expect(publishSource).toContain("artifact.write");
     expect(publishSource).not.toContain("throw new Error");
     expect(publishSource).not.toContain("JSON.parse");
-    expect(publishSource).not.toContain("requiredMarkers");
     expect(publishSource).not.toContain("matchAll");
   });
 });

--- a/packages/cli/test/design-forge-publication.contract.test.ts
+++ b/packages/cli/test/design-forge-publication.contract.test.ts
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { skillExampleWorkflowPath } from "./support/skill-workflow-examples.js";
+
+describe("design-forge publication contract", () => {
+  it("publishes a reader-facing Markdown design separately from the audit trail", async () => {
+    const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
+
+    expect(source).toContain('"design-forge.md"');
+    expect(source).toContain('{ mediaType: "text/markdown" }');
+    expect(source).toContain('"design-forge-package.json"');
+    expect(source).toContain('{ mediaType: "application/json" }');
+    expect(source).toContain('"design-forge-review-log.txt"');
+    expect(source).toContain('{ mediaType: "text/plain" }');
+    expect(source).toContain("not a scratchpad and not a transcript");
+  });
+
+  it("grounds the publication in structured decisions, references, and useful diagrams", async () => {
+    const source = await readFile(skillExampleWorkflowPath("design-forge"), "utf8");
+
+    for (const file of ["references.json", "decision-log.md", "diagram-plan.md"]) {
+      expect(source).toContain(file);
+    }
+    for (const marker of [
+      "summary",
+      "context",
+      "options",
+      "design",
+      "operations",
+      "risks",
+      "delivery",
+      "references",
+    ]) {
+      expect(source).toContain(`design-forge:${marker}`);
+    }
+    expect(source).toContain("new URL(candidate.url).protocol");
+    expect(source).toContain("points to a missing path");
+    expect(source).toContain('trimmed === "```mermaid"');
+    expect(source).toContain("contains unused sources");
+  });
+});


### PR DESCRIPTION
## What changed

Design Forge now keeps the design process Agent-led while publishing a reader-facing Markdown document separately from the challenge history.

- The Designer Agent owns both design quality and document quality. It chooses the structure that fits the brief instead of filling a fixed template.
- Tables, Mermaid diagrams, workspace references, and public citations are optional tools. The Agent uses them only when they materially improve comprehension or support an important claim.
- The three resident challengers still provide fitness, failure, and simplicity pressure, and now also challenge readability and misleading presentation. They are explicitly told not to turn the review into a compliance checklist.
- The workflow retains only two small Tasks: one creates the run-scoped blackboard and one copies the completed Agent-authored document and review log into artifacts.
- The publication Task does not parse schemas, enforce headings or markers, validate citation registries, count diagrams, or reject a best-effort document because of its shape.
- `design-forge.md` is the primary artifact; `design-forge-review-log.txt` preserves the brief and resident challenge history without polluting the reader-facing proposal.

## Why

The previous revision made the output more structured, but it pushed too much editorial policy into deterministic Task code. That treated a best-effort design document like a compiled artifact and introduced brittle failure modes around templates, reference schemas, section markers, and diagram validation.

This revision uses the workflow where it adds real value: Agents author and review semantic content, while Tasks perform only small, predictable filesystem and artifact operations. Reliability continues to come from the resident challenge loop rather than from rigid document conformance.

## Compatibility and cost

- The static graph remains `seed_blackboard -> design_cycle -> publish_blackboard`.
- Each round remains one Designer followed by the same three resident challengers.
- Reviewer session keys, completion schema, concurrency, maximum Agent-call budget, and root output shape are unchanged.
- No final rewriting Agent or additional content-production Task was introduced.

## Validation

- Added a broad contract test for separate Markdown publication and lightweight Task boundaries without locking a document template, citation format, diagram count, or exact prompt wording.
- The existing WorkflowIR contract continues to verify the same two-Task, one-Designer, three-resident-challenger topology.
- CI run #63 passes on Node 22.18.0 and Node 24.x, including clean builds, TypeScript checks, policy checks, the full test suite, dist tests, `git diff --check`, and generated-static-asset cleanliness.