### PR TITLE
fix pnpm check source graph

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -63,6 +63,36 @@
         "test/fixtures/**/*.workflow.ts": ["exports"]
       }
     },
+    "packages/dsh": {
+      "entry": [
+        "test/**/*.{test,test-d}.{ts,tsx}",
+        // The Agent launch resolves this executable by path at runtime.
+        "src/host/dsh-acp-agent-bin.ts!",
+        // TypeScript resolves this import through the generated declaration,
+        // so list the runtime artifact explicitly to check its dependencies.
+        "src/remote/generated.js!"
+      ],
+      "project": [
+        "src/**/*.{ts,tsx}!",
+        "test/**/*.{ts,tsx,mjs}"
+      ],
+      "vitest": false,
+      // The ! suffix limits these exceptions to the production-only strict graph.
+      "ignoreDependencies": [
+        // Public declaration dependency erased from runtime output.
+        "@acpus/expression!",
+        // Type augmentation needed only while compiling the Agent executable.
+        "@deepseek-ai/dsh-agent!",
+        // Loader used only by the workspace source-mode Agent branch.
+        "tsx!"
+      ],
+      "ignoreIssues": {
+        // Canonical generated artifacts intentionally expose one value as
+        // both a named export and the default export.
+        "src/remote/generated.d.ts": ["duplicates"],
+        "src/remote/generated.js": ["duplicates"]
+      }
+    },
     "packages/loader": {
       "entry": ["test/**/*.{test,test-d}.{ts,tsx}"],
       "project": ["src/**/*.ts!", "test/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "clean": "pnpm -r run clean"
   },
   "devDependencies": {
-    "@acpus/runtime": "workspace:*",
     "@changesets/cli": "^2.31.0",
     "@types/node": "^22.20.1",
     "acpus": "workspace:*",
     "esbuild": "^0.28.1",
     "knip": "^6.26.0",
+    "semver": "^7.8.4",
     "slash": "^3.0.0",
     "typescript": "7.0.2",
     "vitest": "^4.1.10"

--- a/packages/agent-executor/src/ownership.ts
+++ b/packages/agent-executor/src/ownership.ts
@@ -11,7 +11,7 @@ import type { AcpOwnershipHealth, AcpOwnershipManifest, ManagedAcpExecutorOption
 
 const MANIFEST_MODE = 0o600;
 
-export type AcpOwnershipInspectionInput = {
+type AcpOwnershipInspectionInput = {
   workersRoot: string;
   owner?: { generation: string | number; pid?: number; startToken?: string };
 };

--- a/packages/dsh/package.json
+++ b/packages/dsh/package.json
@@ -78,7 +78,6 @@
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo"
   },
   "dependencies": {
-    "@acpus/core": "workspace:*",
     "@acpus/expression": "workspace:*",
     "@acpus/runtime": "workspace:*",
     "@acpus/workflow-compiler": "workspace:*",
@@ -96,7 +95,6 @@
     "@deepseek-ai/cordis": "4.0.1",
     "@deepseek-ai/cordis-plugin-loader": "1.0.2",
     "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
-    "@deepseek-ai/dsh-agent-presets": "0.1.0-rc.6",
     "@deepseek-ai/dsh-client-runtime": "0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-conversation": "0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-slots": "0.1.0-rc.6",
@@ -104,7 +102,6 @@
     "@deepseek-ai/dsh-invariants": "0.1.0-rc.6",
     "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
     "@deepseek-ai/dsh-session": "0.1.0-rc.6",
-    "@deepseek-ai/dsh-session-persistence": "0.1.0-rc.6",
     "@deepseek-ai/dsh-system-prompt": "0.1.0-rc.6",
     "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-generator": "0.1.0-rc.6",
@@ -112,8 +109,6 @@
     "@types/react-dom": "^18.3.1",
     "esbuild": "^0.28.1",
     "jsdom": "^28.1.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "tsx": "^4.23.0"
   },
   "peerDependencies": {

--- a/packages/dsh/src/host/run-projection.ts
+++ b/packages/dsh/src/host/run-projection.ts
@@ -6,7 +6,7 @@ import type { AdmittedRunLink } from "./run-links.js";
 type InspectionTreeEntry = Extract<InspectionView, { kind: "run" }>["tree"][number];
 type InspectionVisibleState = Extract<InspectionTreeEntry, { type: "item" }>["state"];
 
-export type StoredSignalRequirement = {
+type StoredSignalRequirement = {
   selector: string;
   prompt?: string;
   expected?: string;

--- a/packages/dsh/src/host/session-agent.ts
+++ b/packages/dsh/src/host/session-agent.ts
@@ -147,7 +147,7 @@ export class ParentSessionAgentAdapter {
   }
 }
 
-export function hasMessage(events: readonly SessionEvent[], messageId: string): boolean {
+function hasMessage(events: readonly SessionEvent[], messageId: string): boolean {
   for (const event of events) {
     if (event.type === "user/message" && event.data.id === messageId) return true;
     if (event.type === "agent/inbox/spliced"

--- a/packages/dsh/src/host/submission.ts
+++ b/packages/dsh/src/host/submission.ts
@@ -10,7 +10,7 @@ import { AcpusOperationError } from "./errors.js";
 import type { RunLink, RunLinkStore } from "./run-links.js";
 import type { ResolvedTaskSelector } from "../task.js";
 
-export type WorkflowDiagnostic = {
+type WorkflowDiagnostic = {
   code: string;
   severity: "error" | "info" | "warning";
   message: string;

--- a/packages/dsh/src/task.ts
+++ b/packages/dsh/src/task.ts
@@ -4,9 +4,3 @@ export type ResolvedTaskSelector = {
 };
 
 export type DelegatedTaskSelector = ResolvedTaskSelector;
-
-export function taskSelector(
-  task: { workflowName: string; occurrence: number },
-): ResolvedTaskSelector {
-  return { name: task.workflowName, occurrence: task.occurrence };
-}

--- a/packages/runtime/src/daemon/protocol.ts
+++ b/packages/runtime/src/daemon/protocol.ts
@@ -12,7 +12,6 @@ import {
   type RuntimeControlResult,
 } from "../runtime-contracts.js";
 
-export { RUNTIME_ABI_VERSION };
 export type { RuntimeAuthorityIdentity };
 
 export const DAEMON_PROTOCOL_VERSION = 4;

--- a/packages/runtime/src/runtime-history.ts
+++ b/packages/runtime/src/runtime-history.ts
@@ -31,7 +31,7 @@ export type ArchivedRunLookup =
   | { kind: "not-found" }
   | { kind: "unavailable"; message: string };
 
-export async function listRuntimeGenerations(
+async function listRuntimeGenerations(
   cwd: string,
   options: RuntimeLayoutOptions = {},
 ): Promise<RuntimeGenerationSummary[]> {

--- a/packages/runtime/src/store/store.ts
+++ b/packages/runtime/src/store/store.ts
@@ -273,7 +273,7 @@ type HookDispatchEventRead = {
   events: CommittedRuntimeEventRow[];
 };
 
-export type RuntimeWork = {
+type RuntimeWork = {
   startableRuns: RunRecord[];
   hookDispatchRunIds: string[];
   idleBlockers: number;
@@ -372,7 +372,7 @@ export type FrozenRun = {
   meta: Record<string, string>;
 };
 
-export type ClaimRuntimeAuthorityInput = {
+type ClaimRuntimeAuthorityInput = {
   workspaceRealpath: string;
   ownerId: string;
   pid: number;
@@ -384,7 +384,7 @@ export type ClaimRuntimeAuthorityInput = {
   idleStopMs?: number;
 };
 
-export type RuntimeAuthorityFence = {
+type RuntimeAuthorityFence = {
   workspaceRealpath: string;
   ownerId: string;
   epoch: number;
@@ -395,7 +395,7 @@ type RuntimeAuthorityIdleStateInput = RuntimeAuthorityFence & {
   idleStopMs: number;
 };
 
-export type RuntimeAuthorityLease = {
+type RuntimeAuthorityLease = {
   workspaceRealpath: string;
   ownerId: string;
   epoch: number;

--- a/packages/runtime/src/workspace-runtime.ts
+++ b/packages/runtime/src/workspace-runtime.ts
@@ -121,7 +121,7 @@ export interface WorkspaceRuntime {
   close(): Promise<void>;
 }
 
-export type WorkspaceRuntimeActivity = {
+type WorkspaceRuntimeActivity = {
   activeSessions: number;
   activeHooks: number;
   activeMutations: boolean;

--- a/packages/runtime/test/support/runtime-fixtures.ts
+++ b/packages/runtime/test/support/runtime-fixtures.ts
@@ -1,8 +1,8 @@
 import { admitRunForTest } from "./runtime-store.js";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
-import { basename, join, relative, resolve } from "node:path";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 import { defineWorkflow, z } from "@acpus/core";
@@ -17,7 +17,6 @@ import {
   type Sha256Digest,
   type WorkflowSourceFile,
 } from "@acpus/runtime";
-import { prepareWorkflow } from "@acpus/workflow-compiler";
 import { openRuntimeStore, type RuntimeStore } from "../../src/store/store.js";
 import { resolveRuntimeLayout, setRuntimeHomeForTest } from "../../src/runtime-layout.js";
 import { stableJson } from "../../src/stable-json.js";
@@ -25,12 +24,7 @@ import { advanceRuntimeRun } from "./scheduler.js";
 import { throwingSchedulerStore } from "./scheduler-store.js";
 
 const repoRoot = resolve(fileURLToPath(new URL("../../../..", import.meta.url)));
-const runtimeFixtureRoot = join(repoRoot, "packages", "runtime", "test", "fixtures");
 type SnapshotPreparedWorkflow = Extract<PreparedRunWorkflow, { source: { kind: "snapshot" } }>;
-
-function fixturePath(relativePath: string): string {
-  return join(runtimeFixtureRoot, relativePath);
-}
 
 export async function withRuntimeWorkspace<T>(
   name: string,
@@ -85,15 +79,6 @@ async function writeWorkspaceTsconfig(workspace: string): Promise<void> {
 async function linkWorkspaceCore(workspace: string): Promise<void> {
   await mkdir(join(workspace, "packages"), { recursive: true });
   await symlink(join(repoRoot, "packages", "core"), join(workspace, "packages", "core"), "dir");
-}
-
-export async function prepareFixture(workspace: string, relativePath: string): Promise<PreparedRunWorkflow> {
-  const target = join(workspace, basename(relativePath).replace(/\.fixture$/, ".ts"));
-  await copyFile(fixturePath(relativePath), target);
-  return prepareWorkflow({
-    workspaceDir: workspace,
-    source: { kind: "path", entry: target },
-  }) as Promise<PreparedRunWorkflow>;
 }
 
 export async function prepareSyntheticWorkflow(workspace: string, definition: WorkflowDefinition<any, any>, filename = `${definition.config.name}.workflow.ts`): Promise<PreparedRunWorkflow> {

--- a/packages/workflow-compiler/test/support/preflight.ts
+++ b/packages/workflow-compiler/test/support/preflight.ts
@@ -32,12 +32,6 @@ export async function expectPreparationFailure(
   throw new Error("expected workflow preparation to fail");
 }
 
-export function workflowSource(name: string): string {
-  return `import { defineWorkflow } from "acpus/core";
-export default defineWorkflow({ name: ${JSON.stringify(name)} }).build(() => ({}));
-`;
-}
-
 export function fixture(relativePath: string): string {
   return join(fixturesRoot, relativePath);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@acpus/runtime':
-        specifier: workspace:*
-        version: link:packages/runtime
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@22.20.1)
@@ -26,6 +23,9 @@ importers:
       knip:
         specifier: ^6.26.0
         version: 6.26.0
+      semver:
+        specifier: ^7.8.4
+        version: 7.8.5
       slash:
         specifier: ^3.0.0
         version: 3.0.0
@@ -125,9 +125,6 @@ importers:
 
   packages/dsh:
     dependencies:
-      '@acpus/core':
-        specifier: workspace:*
-        version: link:../core
       '@acpus/expression':
         specifier: workspace:*
         version: link:../expression
@@ -195,9 +192,6 @@ importers:
       '@deepseek-ai/dsh-session':
         specifier: 0.1.0-rc.6
         version: 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
-      '@deepseek-ai/dsh-session-persistence':
-        specifier: 0.1.0-rc.6
-        version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-system-prompt':
         specifier: 0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
@@ -5579,7 +5573,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@changesets/assemble-release-plan@6.0.10':
     dependencies:
@@ -5588,7 +5582,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -5619,7 +5613,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.8.4
+      semver: 7.8.5
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -5645,7 +5639,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.4
+      semver: 7.8.5
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:

--- a/scripts/check-plan.mjs
+++ b/scripts/check-plan.mjs
@@ -49,7 +49,6 @@ const tasks = new Map([
     commands: [{
       packageBin: ["knip", "knip"],
       args: [
-        "--include-entry-exports",
         "--include",
         sourceGraphIssues,
         "--treat-config-hints-as-errors",

--- a/scripts/check-plan.test.mjs
+++ b/scripts/check-plan.test.mjs
@@ -65,6 +65,7 @@ test("the runner stops at the first failed task", async () => {
 
 test("the source graph covers dead code and dependency issues in one Knip command", () => {
   const [command] = resolveCheckPlan(["graph:source"])[0].commands;
+  assert(!command.args.includes("--include-entry-exports"));
   const included = command.args[command.args.indexOf("--include") + 1].split(",");
   assert.deepEqual(included, [
     "files",

--- a/scripts/verify-dist.js
+++ b/scripts/verify-dist.js
@@ -41,7 +41,7 @@ try {
   await createConsumer(consumerDirectory, packages);
   await runPnpm([
     "install",
-    "--offline",
+    "--prefer-offline",
     "--ignore-scripts",
     "--no-frozen-lockfile",
     "--reporter=append-only",


### PR DESCRIPTION
## Summary

- stop the source graph check from treating public package entry exports as workspace dead code, with a regression assertion on the check plan
- model DSH's path-resolved Agent executable and generated Remote runtime as Knip entries, while keeping source-mode/type-only exceptions limited to the strict production graph
- remove confirmed dead exports, helpers, and duplicate dependencies, and declare the `semver` dependency used by the distribution verifier
- make the distribution smoke consumer prefer cached packages without requiring registry metadata to already exist in a cold runner cache

## Root cause

The source graph ran Knip with `--include-entry-exports`, so public package APIs that are intentionally consumed outside the monorepo were reported as unused. The newly merged DSH package also introduced runtime-path and generated entry points that the generic workspace configuration could not discover, plus several stale dependency/export declarations.

The distribution verifier created a temporary consumer without a lockfile and installed it with strict `--offline` resolution. A clean GitHub runner could have package contents restored in pnpm's store while still lacking `@deepseek-ai/cordis` registry metadata, causing `ERR_PNPM_NO_OFFLINE_META`. `--prefer-offline` keeps local-store reuse and fetches only missing metadata.

## Impact

`pnpm check` succeeds on current `main` while continuing to report internal dead code and dependency graph errors. Public package APIs are no longer mistaken for repository-internal unused exports, and `pnpm test:dist` no longer depends on an implicitly warm metadata cache.

## Validation

Reproduced the dist failure with an empty `XDG_CACHE_HOME`, then verified the fix with the same cold cache.

Ran both complete CI matrix jobs locally in workflow order:

- Node 22.18.0: install, clean build, typecheck, toolchain check, full test suite, dist smoke, and both diff gates
- Node 24.19.0: install, clean build, typecheck, full `pnpm check`, full test suite, dist smoke, and both diff gates

GitHub Actions [CI run #112](https://github.com/kelvinschen/acpus/actions/runs/31947567225) passed both matrix jobs.
