### PR TITLE
Use robot icon for Agent Profiles

### DIFF
--- a/packages/dsh/package.json
+++ b/packages/dsh/package.json
@@ -86,7 +86,6 @@
     "@deepseek-ai/dsh-acp": "0.1.0-rc.6",
     "@deepseek-ai/dsh-app-boot": "0.1.0-rc.6",
     "@deepseek-ai/dsh-base": "0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-primitives": "0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-protocol": "0.1.0-rc.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/dsh/scripts/build-client.mjs
+++ b/packages/dsh/scripts/build-client.mjs
@@ -8,7 +8,6 @@ await build({
   platform: "browser",
   target: "es2022",
   external: [
-    "@deepseek-ai/dsh-client-ui-primitives",
     "react",
     "react/jsx-runtime",
     "react-dom",

--- a/packages/dsh/src/client/profile-action.tsx
+++ b/packages/dsh/src/client/profile-action.tsx
@@ -1,5 +1,4 @@
 import type { PropsRuntime } from "@deepseek-ai/dsh-client-ui-slots";
-import { IconUserOutline16 } from "@deepseek-ai/dsh-client-ui-primitives";
 import {
   useCallback,
   useEffect,
@@ -124,7 +123,7 @@ export function AcpusProfileAction({
           load();
         }}
       >
-        <IconUserOutline16 size={14} />
+        <RobotIcon size={14} />
         <span>Agent Profiles</span>
       </button>
       {open && (
@@ -154,6 +153,27 @@ export function AcpusProfileAction({
         </div>
       )}
     </div>
+  );
+}
+
+function RobotIcon({ size }: { size: number }) {
+  return (
+    <svg
+      className="acpus-profile-robot-icon"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 8V4H8" />
+      <rect width="16" height="12" x="4" y="8" rx="2" />
+      <path d="M2 14h2M20 14h2M15 13v2M9 13v2" />
+    </svg>
   );
 }
 

--- a/packages/dsh/test/client-activation.unit.test.ts
+++ b/packages/dsh/test/client-activation.unit.test.ts
@@ -1,10 +1,6 @@
 import { Context, Service } from "@deepseek-ai/cordis";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@deepseek-ai/dsh-client-ui-primitives", () => ({
-  IconUserOutline16: () => null,
-}));
-
 import * as client from "@acpus/dsh/client";
 
 describe("Acpus Client activation", () => {

--- a/packages/dsh/test/client-profile-action.unit.test.ts
+++ b/packages/dsh/test/client-profile-action.unit.test.ts
@@ -5,11 +5,6 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@deepseek-ai/dsh-client-ui-primitives", () => ({
-  IconUserOutline16: ({ size = 16 }: { size?: number }) =>
-    React.createElement("svg", { height: size, width: size }),
-}));
-
 import {
   AcpusBrandLabel,
   AcpusProfileAction,
@@ -72,7 +67,7 @@ describe("Acpus Agent Profiles header action", () => {
     await renderAction(readAgentProfiles);
     const trigger = button("Agent Profiles");
     expect(trigger).toBeDefined();
-    expect(trigger?.querySelector("svg")).not.toBeNull();
+    expect(trigger?.querySelector("svg.acpus-profile-robot-icon")).not.toBeNull();
     expect(trigger?.getAttribute("aria-haspopup")).toBe("dialog");
 
     await act(async () => trigger?.click());

--- a/packages/dsh/test/public-api.contract.test.ts
+++ b/packages/dsh/test/public-api.contract.test.ts
@@ -2,10 +2,6 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@deepseek-ai/dsh-client-ui-primitives", () => ({
-  IconUserOutline16: () => null,
-}));
-
 import Loader from "@deepseek-ai/cordis-plugin-loader";
 import { scanRoot } from "@deepseek-ai/dsh-agent-presets";
 import AcpusMode, {
@@ -122,7 +118,6 @@ describe("@acpus/dsh public contract", () => {
       "@deepseek-ai/dsh-acp": "0.1.0-rc.6",
       "@deepseek-ai/dsh-app-boot": "0.1.0-rc.6",
       "@deepseek-ai/dsh-base": "0.1.0-rc.6",
-      "@deepseek-ai/dsh-client-ui-primitives": "0.1.0-rc.6",
     });
     expect(manifest.files).toContain("acp-agent");
     expect(manifest.files).toContain("README.md");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       '@deepseek-ai/dsh-base':
         specifier: 0.1.0-rc.6
         version: 0.1.0-rc.6(1351052ffc0a403da46107992b493470)
-      '@deepseek-ai/dsh-client-ui-primitives':
-        specifier: 0.1.0-rc.6
-        version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-protocol':
         specifier: 0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))

--- a/specs/dsh-spec.md
+++ b/specs/dsh-spec.md
@@ -479,7 +479,7 @@ cancelSessionTask(input: {
 - In an Acpus-preset session, the Client MUST always register a title-adjacent
   non-interactive Acpus × DSH lockup in place of the normal textual preset
   label; hovering the lockup MUST expose the Acpus mode description. It is
-  immediately followed by an `Agent Profiles` action with a member icon,
+  immediately followed by an `Agent Profiles` action with a robot icon,
   including when the catalog has no user-defined Profiles. Opening the action
   MUST read the current global catalog and
   show the immutable built-in `dsh` Profile first, followed by user Profiles in


### PR DESCRIPTION
## What changed

- Replace the `Agent Profiles` header action's person silhouette with a robot outline.
- Keep the icon theme-aware through `currentColor` and hide the decorative SVG from assistive technology.
- Update the DSH specification and focused UI regression coverage.
- Remove the now-unused `dsh-client-ui-primitives` dependency and related test mocks/build external.

## Why

Agent Profiles represent executable agents rather than human members, so the previous person icon communicated the wrong concept. The robot glyph makes the action's purpose clearer.

## Validation

- `pnpm --filter @acpus/dsh build`
- `pnpm --filter @acpus/dsh typecheck`
- `pnpm test:unit packages/dsh`
- `pnpm test:contract packages/dsh`
- `pnpm test`
- `pnpm typecheck`